### PR TITLE
Don't filter "Shepherd" and replace "RFCs" with "Attention"

### DIFF
--- a/chrome-app/links.js
+++ b/chrome-app/links.js
@@ -59,13 +59,13 @@ const LINKS = [
     },
     {
       title: "Shepherd",
-      href: gitHubQuery("https://github.com/pulls", [...pr, "assignee:USERNAME", "-author:USERNAME", "review:required" ]),
-      description: "Contributor pull requests you are responsible for reviewing and merging",
+      href: gitHubQuery("https://github.com/pulls", [...pr, "assignee:USERNAME", "-author:USERNAME" ]),
+      description: "PRs assigned to you",
     },
     {
-      title: "RFCs",
-      href: gitHubQuery("https://github.com/pulls", [...pr, "label:management/rfc" ]),
-      description: "Requests for comments",
+      title: "Attention",
+      href: gitHubQuery("https://github.com/pulls", [...pr, "assignee:USERNAME", "-author:USERNAME", "review:required" ]),
+      description: "Contributor pull requests you are responsible for reviewing and merging",
     },
     {
       title: "Finish",


### PR DESCRIPTION
RFCs should surface either under "Finish" or "Review", so I don't see too much value in a separate tab for them.

The "Shepherd" tab now does not filter only PRs with "review requested" but otherwise just shows all assigned PRs. This will surface stale PRs which owners are expected to drive to a close.

Added the "Attention" PR for PRs that require attention (i.e. Review Requested).